### PR TITLE
Improve power check with rough energy estimate

### DIFF
--- a/MiningDroneScript.cs
+++ b/MiningDroneScript.cs
@@ -77,7 +77,27 @@ private bool IsCargoFull()
 
 private bool HasEnoughPower()
 {
-    return battery.CurrentStoredPower / battery.MaxStoredPower > 0.3f; // >30%
+    // Roughly estimate the power needed to fly back to the base.
+    // We multiply the distance to the base by the current ship mass and a
+    // constant factor representing average power consumption. This is a very
+    // coarse approximation but helps prevent the drone from running out of
+    // energy mid-flight.
+    double distance = Vector3D.Distance(rc.GetPosition(), basePosition); // meters
+    double mass = rc.CalculateShipMass().TotalMass; // kg
+
+    // Assume the ship uses about 0.00001 MW for each kilogram of mass while
+    // traveling at cruise speed (~50 m/s). Energy needed is power * time.
+    double avgPower = mass * 0.00001; // MW
+    double travelTimeHours = (distance / 50.0) / 3600.0; // convert seconds to hours
+    double energyNeeded = avgPower * travelTimeHours; // MWh required to reach base
+
+    // Return false if we don't have enough stored power for the return trip.
+    double remainingPower = battery.CurrentStoredPower; // MWh
+    if (remainingPower < energyNeeded)
+        return false;
+
+    // Otherwise ensure we still keep a 30% reserve as before.
+    return remainingPower / battery.MaxStoredPower > 0.3f;
 }
 
 private void StartDockingSequence()


### PR DESCRIPTION
## Summary
- estimate the energy needed to fly back to the base using distance, ship mass and an assumed power consumption constant
- adjust `HasEnoughPower()` to check the estimated power usage before allowing the drone to continue
- document the rough approximation in comments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688552d62d048333b0a771ea9b64ef6e