### PR TITLE
Remove unused cargo variable

### DIFF
--- a/MiningDroneScript.cs
+++ b/MiningDroneScript.cs
@@ -22,7 +22,6 @@ private IMyRemoteControl rc;
 private List<IMyThrust> thrusters = new List<IMyThrust>();
 private List<IMyGyro> gyros = new List<IMyGyro>();
 private IMyShipConnector connector;
-private IMyCargoContainer cargo;
 private List<IMyCargoContainer> cargoContainers = new List<IMyCargoContainer>();
 private IMyShipDrill drill;
 private IMyBatteryBlock battery;
@@ -92,11 +91,6 @@ private void Init()
     }
 
     GridTerminalSystem.GetBlocksOfType(cargoContainers);
-    cargo = GridTerminalSystem.GetBlockWithName("Cargo") as IMyCargoContainer;
-    if(cargo == null && cargoContainers.Count > 0)
-    {
-        cargo = cargoContainers[0];
-    }
     drill = GridTerminalSystem.GetBlockWithName("Drill") as IMyShipDrill;
     battery = GridTerminalSystem.GetBlockWithName("Battery") as IMyBatteryBlock;
 


### PR DESCRIPTION
## Summary
- remove leftover `cargo` variable and initialization
- keep using `cargoContainers` list for inventory checks and transfers

## Testing
- `dotnet` and `mono` were unavailable so no build or tests could be run

------
https://chatgpt.com/codex/tasks/task_e_68855747e400833395241c31f428a1a1